### PR TITLE
Add prop to change repo for each sveltejs project

### DIFF
--- a/components/Docs.svelte
+++ b/components/Docs.svelte
@@ -4,6 +4,7 @@
 	import Icon from './Icon.svelte';
 	import { getFragment } from '../utils/navigation';
 
+	export let project = 'svelte';
 	export let sections;
 	let active_section;
 
@@ -363,7 +364,7 @@
 
 				{section.metadata.title}
 				<small>
-					<a href='https://github.com/sveltejs/svelte/edit/master/site/content/docs/{section.file}' title='edit this section'>
+					<a href='https://github.com/sveltejs/{project}/edit/master/site/content/docs/{section.file}' title='edit this section'>
 						<Icon name='edit' /></a>
 				</small>
 			</h2>


### PR DESCRIPTION
Adds a prop `project` to the Docs component so that the 'edit this page' button works for other projects besides svelte. Has a default value `svelte` so it doesn't break things when merged.

This prop can be used on the sapper docs `site/src/routes/docs/index.svelte` like so...

https://github.com/sveltejs/sapper/blob/75afc691f4b47a3d9d1f8c933a5efeb218ceaa51/site/src/routes/docs/index.svelte#L22

```
<Docs {sections} project='sapper'/>
```

Question for maintainer:
Just one consideration, would it make it more clear to use the word `repo` or `repository` instead of `project`? I can update the PR if that's the case.