### PR TITLE
add  rel="noopener noreferrer" to links for security

### DIFF
--- a/utils/markdown.js
+++ b/utils/markdown.js
@@ -57,5 +57,5 @@ export function link_renderer (href, title, text) {
 		title_attr = ` title="${title}"`;
 	}
 
-	return `<a href="${href}"${target_attr}${title_attr}>${text}</a>`;
+	return `<a href="${href}"${target_attr}${title_attr} rel="noopener noreferrer">${text}</a>`;
 }


### PR DESCRIPTION
add  rel="noopener noreferrer" to links for security

lighthouse caught this, i assume you know what it is already but let me know if a further justificaiton is needed

![image](https://user-images.githubusercontent.com/6764957/64901902-a3893100-d66c-11e9-81a0-9ba27a44bd54.png)
