### PR TITLE
Fixing border of "Learn ..." button on home page

### DIFF
--- a/components/Blurb.svelte
+++ b/components/Blurb.svelte
@@ -75,6 +75,7 @@
 		background-color: var(--prime);
 		padding: 0.5em 1.8em 0.5em 1em;
 		border-radius: var(--border-r);
+		border: none;
 		color: white;
 		position: relative;
 	}


### PR DESCRIPTION
A white border on the bottom apear when hovering the link. This cause some displacement.

I solved it by adding a `border: none;` in the css. Every other links were already doing this, but this one has probably been forgotten.

### Before
![](https://i.gyazo.com/d1e7bd3df3239d9d92712fa107540701.gif)
![](https://i.gyazo.com/08e7d37ec27ff375b85f93ac9069cfa2.gif)

### After
![](https://i.gyazo.com/2ad717085fcee90196931a648f91021b.gif)