### PR TITLE
Add focus style to anchor elements

### DIFF
--- a/base.css
+++ b/base.css
@@ -127,7 +127,10 @@ a {
 }
 
 a:hover, a:active { color: var(--flash) }
-a:focus { outline: none }
+a:focus {
+	outline: 2px solid var(--prime);
+	padding-top: 2px;
+}
 
 /*
 -----------------------------------------------


### PR DESCRIPTION
Fixes #10 

The styling is nothing crazy - just a simple outline that is easy to notice for keyboard users, allowing them to navigate the page.