### PR TITLE
Change languages.

### DIFF
--- a/utils/markdown.js
+++ b/utils/markdown.js
@@ -38,7 +38,7 @@ export function extract_metadata(line, lang) {
 export const langs = {
 	bash: 'bash',
 	html: 'markup',
-	sv: 'markup',
+	sv: 'svelte',
 	js: 'javascript',
 	css: 'css'
 };


### PR DESCRIPTION
Required to add svelte syntax highlighting to the svelte site.

We could change html to svelte as well, the svelte highlighter supports all html syntax.