### PR TITLE
Don't remove the outline on focus

### DIFF
--- a/base.css
+++ b/base.css
@@ -232,9 +232,6 @@ button {
 	cursor: pointer;
 }
 
-button:focus,
-.btn:focus { outline: 0 }
-
 button[disabled],
 .btn[disabled],
 .btn:hover[disabled] {

--- a/base.css
+++ b/base.css
@@ -127,7 +127,6 @@ a {
 }
 
 a:hover, a:active { color: var(--flash) }
-a:focus { outline: none }
 
 /*
 -----------------------------------------------


### PR DESCRIPTION
To be able to navigate with the keyboard, you need focus styles. Removing focus styles while not providing an alternative is not good for accessibility.

Signed-off-by: Wolfr <johan.ronsse@gmail.com>