### PR TITLE
fix(NavItem): added missing title property

### DIFF
--- a/components/NavItem.svelte
+++ b/components/NavItem.svelte
@@ -3,12 +3,13 @@
 
 	export let segment = null;
 	export let external = null;
+	export let title = null;
 
 	const current = getContext('nav');
 </script>
 
 {#if external}
-	<li><a href={external}><slot></slot></a></li>
+	<li><a href={external} {title}><slot></slot></a></li>
 {:else}
-	<li class:active="{$current === segment}"><a rel="prefetch" href={segment}><slot></slot></a></li>
+	<li class:active="{$current === segment}"><a rel="prefetch" href={segment} {title}><slot></slot></a></li>
 {/if}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/787658/77803164-c7e2b300-707c-11ea-887b-3c758eb34c92.png)

> Links do not have a discernible name

is being reported by _Google Lighthouse_ for the icon navigation links within the header on [svelte.dev](https://svelte.dev/), the ones shown on this screenshot:
![image](https://user-images.githubusercontent.com/787658/77803339-2d36a400-707d-11ea-9719-ecf99b49a173.png)

This is most likely related to that [/sveltejs/svelte/blob/master/site/src/routes/_layout.svelte](https://github.com/sveltejs/svelte/blob/master/site/src/routes/_layout.svelte) includes `title` property declarations for `site-kit`'s `NavItem` component, but those aren't included in the component itself.

Same for problem related to [sapper.svelte.dev](https://sapper.svelte.dev/): https://github.com/sveltejs/sapper/blob/master/site/src/routes/_layout.svelte