### PR TITLE
fixing: right arrow getting clipped next to 'learn more'

### DIFF
--- a/components/Blurb.svelte
+++ b/components/Blurb.svelte
@@ -57,9 +57,9 @@
 		position: absolute;
 		display: block;
 		right: 0;
-		top: 0.35em;
-		width: 1em;
-		height: 1em;
+		top: 0;
+		width: 1.25em;
+		height: 1.25em;
 		background: url(/icons/arrow-right.svg);
 	}
 


### PR DESCRIPTION
In the `Blurb` cards, the right arrow next to 'learn more' was getting clipped due to its positioning. Since the icon is 24px by 24px, changing the width and height fixed the issue.

Before:
![Screenshot from 2020-04-26 18-54-53](https://user-images.githubusercontent.com/9134050/80309254-86ffca80-87f1-11ea-8231-76acae42cd9a.png)

![Screenshot from 2020-04-26 18-54-43](https://user-images.githubusercontent.com/9134050/80309253-82d3ad00-87f1-11ea-826e-f76b2d3f5ac4.png)

After:
![Screenshot from 2020-04-26 19-11-35](https://user-images.githubusercontent.com/9134050/80309302-e231bd00-87f1-11ea-9fd8-92324521aa72.png)

![Screenshot from 2020-04-26 19-10-45](https://user-images.githubusercontent.com/9134050/80309306-e3fb8080-87f1-11ea-862c-4bede6f64955.png)
