### PR TITLE
use '🡪' as a right arrow icon instead of an SVG

### DIFF
--- a/components/Blurb.svelte
+++ b/components/Blurb.svelte
@@ -53,14 +53,10 @@
 	}
 
 	.box :global(.learn-more)::after, .box :global(.cta) :global(a)::after {
-		content: '';
+		content: '🡪';
 		position: absolute;
-		display: block;
 		right: 0;
 		top: 0.35em;
-		width: 1em;
-		height: 1em;
-		background: url(/icons/arrow-right.svg);
 	}
 
 	.how {


### PR DESCRIPTION
i am proposing to use '🡪' (WIDE-HEADED RIGHTWARDS BARB ARROW) as right-arrow icon. To reduce payload size. This also cuts one request.