### PR TITLE
fix: input css on iOS

### DIFF
--- a/base.css
+++ b/base.css
@@ -440,7 +440,9 @@ input[type="checkbox"] {
 	top: -2px;
 	border-radius: 0.5em;
 	-webkit-appearance: none;
+	appearance: none;
 	outline: none;
+	border: transparent;
 	margin: 0 0.6em 0 0;
 }
 


### PR DESCRIPTION
Fixed the CSS issue on iOS web browsers where the input knob was off center and there was a system style behind the knob too.

<img width="104" alt="Image 2020-07-17 at 1 51 41 PM" src="https://user-images.githubusercontent.com/2502947/87816085-bba18200-c834-11ea-9f6a-a972d590df25.png">


<img width="1599" alt="Image 2020-07-17 at 1 43 42 PM" src="https://user-images.githubusercontent.com/2502947/87815718-21413e80-c834-11ea-837b-08ab311b8c5c.png">
<img width="1277" alt="Image 2020-07-17 at 1 49 32 PM" src="https://user-images.githubusercontent.com/2502947/87815873-636a8000-c834-11ea-8770-f40cd1bff3a8.png">


To Test:
- `npm link` the PR in site-kit to `svlete` repo in `site` folder
- Run an emulator and then go to localhost. (can use Xcode with a sample iOS app)


If you want to have access to the developer console within safari iOS emulator:
- Go to safari develop tab --> select simulator.
