### PR TITLE
fix #20 strange menu scrollbar behaivor

### DIFF
--- a/components/Docs.svelte
+++ b/components/Docs.svelte
@@ -32,7 +32,7 @@
 		let last_id = getFragment();
 
 		const onscroll = () => {
-			const top = -window.scrollY;
+			const { top } = container.getBoundingClientRect();
 
 			let i = anchors.length;
 			while (i--) {


### PR DESCRIPTION
Because always return `window.scrollY` return `0`.
Alternatively, use `element.getBoundingClientRect().top` to determine
active section.

Relative Issues: #20.