### PR TITLE
Make permalinks accessible

### DIFF
--- a/base.css
+++ b/base.css
@@ -482,3 +482,16 @@ input[type="checkbox"]::after {
 input[type="checkbox"]:checked::after {
 	left: calc(100% - 1em + 2px);
 }
+
+/* visually hidden, but accessible to assistive tech */
+.visually-hidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: auto;
+  margin: 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  white-space: nowrap;
+}

--- a/base.css
+++ b/base.css
@@ -476,13 +476,13 @@ input[type="checkbox"]:checked::after {
 
 /* visually hidden, but accessible to assistive tech */
 .visually-hidden {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: auto;
-  margin: 0;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-  white-space: nowrap;
+	border: 0;
+	clip: rect(0 0 0 0);
+	height: auto;
+	margin: 0;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
+	white-space: nowrap;
 }

--- a/base.css
+++ b/base.css
@@ -139,9 +139,6 @@ body {
 	font: 300 var(--h4)/var(--lh) var(--font);
 	background-color: var(--back);
 	color: var(--text);
-
-	/* default spacing of Overpass is a bit too airy */
-	/* letter-spacing: -.013em; */
 }
 
 h1, h2, h3, h4, h5, h6, blockquote {
@@ -150,7 +147,6 @@ h1, h2, h3, h4, h5, h6, blockquote {
 	color: var(--heading);
 }
 
-/* h1, h2, h3, h4, h5, h6 { font-weight: 600 } */
 h6 { font-size: var(--h6) }
 h5 { font-size: var(--h5) }
 h4 { font-size: var(--h4) }
@@ -261,7 +257,6 @@ button > svg,
 	vertical-align: middle;
 	white-space: nowrap;
 	display: inline-block;
-	zoom: 1;
 	border: none transparent;
 	font: var(--h4) var(--btn-font);
 	border-radius: var(--border-r);
@@ -315,8 +310,6 @@ a.no-underline {
 	border-bottom: none;
 	padding: 0;
 }
-
-/* a:hover:not(.disabled) > .icon { stroke: var(--flash) } */
 
 /*  lists ---------------------------------- */
 .listify ol,
@@ -432,7 +425,6 @@ table code, table span {
 
 /*	inputs --------------------------------- */
 input[type="checkbox"] {
-	/* display: block; */
 	position: relative;
 	height: 1em;
 	width: calc(100% - 0.6em);
@@ -457,7 +449,6 @@ input[type="checkbox"]::before {
 	top: 0;
 	left: 0;
 	background: var(--second);
-	/* box-sizing: border-box; */
 	box-sizing: content-box;
 }
 

--- a/components/Docs.svelte
+++ b/components/Docs.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import GuideContents from './GuideContents.svelte'; // TODO rename
 	import Icon from './Icon.svelte';
+	import Permalink from './Permalink.svelte';
 	import { getFragment } from '../utils/navigation';
 
 	export let owner = 'sveltejs';
@@ -230,7 +231,6 @@
 		left: -1.3em;
 		opacity: 0;
 		transition: opacity 0.2s;
-		border: none !important; /* TODO get rid of linkify */
 	}
 
 	.content :global(h2 > .anchor),
@@ -239,6 +239,7 @@
 	}
 
 	@media (min-width: 768px) {
+		.content :global(.anchor:focus),
 		.content :global(h2):hover :global(.anchor),
 		.content :global(h3):hover :global(.anchor),
 		.content :global(h4):hover :global(.anchor),
@@ -367,10 +368,6 @@
 		cursor: pointer;
 	}
 
-	/* no linkify on these */
-	small a        { all: unset }
-	small a:before { all: unset }
-
 	section :global(blockquote) {
 		color: hsl(204, 100%, 50%);
 		border: 2px solid var(--flash);
@@ -388,10 +385,9 @@
 			<h2>
 				<span class="offset-anchor" id={section.slug}></span>
 
-				<!-- svelte-ignore a11y-missing-content -->
-				<a href="{dir}#{section.slug}" class="anchor" aria-hidden></a>
-
 				{@html section.metadata.title}
+				<Permalink href="{dir}#{section.slug}" />
+				
 				<small>
 					<a href="https://github.com/{owner}/{project}/edit/master{path}/{dir}/{section.file}" title="{edit_title}">
 						<Icon name='edit' />

--- a/components/Permalink.svelte
+++ b/components/Permalink.svelte
@@ -1,0 +1,7 @@
+<script>
+  export let href;
+</script>
+
+<a {href} class="anchor">
+  <span class="visually-hidden">permalink</span>
+</a>

--- a/components/Permalink.svelte
+++ b/components/Permalink.svelte
@@ -1,7 +1,7 @@
 <script>
-  export let href;
+	export let href;
 </script>
 
 <a {href} class="anchor">
-  <span class="visually-hidden">permalink</span>
+	<span class="visually-hidden">permalink</span>
 </a>

--- a/index.mjs
+++ b/index.mjs
@@ -5,4 +5,5 @@ export { default as Icon } from './components/Icon.svelte';
 export { default as Icons } from './components/Icons.svelte';
 export { default as Nav } from './components/Nav.svelte';
 export { default as NavItem } from './components/NavItem.svelte';
+export { default as Permalink } from './components/Permalink.svelte';
 export { default as Section } from './components/Section.svelte';

--- a/utils/markdown.js
+++ b/utils/markdown.js
@@ -60,3 +60,10 @@ export function link_renderer (href, title, text) {
 
 	return `<a href="${href}"${target_attr}${title_attr} rel="noopener noreferrer">${text}</a>`;
 }
+
+export function permalink(href) {
+	return `
+		<a href="${href}" class="anchor">
+			<span class="visually-hidden">permalink</span>
+		</a>`;
+}


### PR DESCRIPTION
This updates how permalinks are rendered to resolve some of the Axe violations in https://github.com/sveltejs/svelte/issues/5678.

Summary of changes:
- Remove aria-hidden from permalinks. This fixes the Axe violation [ARIA hidden element must not contain focusable elements](https://dequeuniversity.com/rules/axe/4.0/aria-hidden-focus?application=AxeChrome)
- Add visually hidden text to each permalink so assistive tech knows what the link is
- Move permalink code into a Svelte component and a markdown helper for dependent sites to consume (e.g. svelte.dev)
- Make focus visible when focusing permalinks and edit links. Previously there was either no focus outline (on edit links) or the element still had opacity 0 (permalinks)
- CSS cleanup
  - Remove commented out CSS
  - Remove [non-standard zoom property](https://developer.mozilla.org/en-US/docs/Web/CSS/zoom). Including this property logs a console warning on firefox and is only needed for an IE bug
  - Remove rules related to linkify. I searched the project and it seems like linkify is no longer used. I can put these back if I'm wrong.

I'll be opening a separate PR for the svelte.dev site that is dependent on these changes.

