### PR TITLE
Add rss icon

### DIFF
--- a/components/Icons.svelte
+++ b/components/Icons.svelte
@@ -102,5 +102,11 @@
 		<symbol id="chevron" class="icon" viewBox="0 0 24 24">
 			<path d="M2,7 L12,17 L20,7"/>
 		</symbol>
+
+		<symbol id="rss" class="icon" viewBox="0 0 24 24">
+			<path d="M4 11a9 9 0 0 1 9 9"/>
+			<path d="M4 4a16 16 0 0 1 16 16"/>
+			<circle cx="5" cy="19" r="1"/>
+		</symbol>
 	</svg>
 </div>


### PR DESCRIPTION
# Summary
Adds an RSS icon to the icon library taken from from https://feathericons.com/?query=rss

# Motivation
As discussed in Discord, so that we can add an `<Icon name="rss"> RSS Feed` to the bottom of https://svelte.dev/blog. I figured it would be helpful for people who need a direct link to the RSS feed so they don't need to go looking through the page source

# Test plan
Tested on the REPL: You can see this in action at https://svelte.dev/repl/1f1ae8d9d155435f82549f97d9d36a9c?version=3.32.0