### PR TITLE
fix heading issue in <Hero>

### DIFF
--- a/components/Hero.svelte
+++ b/components/Hero.svelte
@@ -15,18 +15,18 @@
 		max-width: 120rem;
 	}
 
-	h3 { color: var(--text) }
+	p { color: var(--text) }
 
 	.hero {
 		margin: 10rem auto;
 	}
 
-	.hero h3, .logotype {
+	.hero p, .logotype {
 		position: relative;
 		left: 1.6rem;
 	}
 
-	.hero h3 {
+	.hero p {
 		font-size: 2rem;
 	}
 
@@ -39,7 +39,7 @@
 			height: 6rem;
 		}
 
-		.hero h3 {
+		.hero p {
 			font-size: var(--h3);
 		}
 	}
@@ -49,7 +49,7 @@
 			margin: 15rem auto;
 		}
 
-		.hero h3, .logotype {
+		.hero p, .logotype {
 			left: 3rem;
 		}
 	}
@@ -59,5 +59,5 @@
 
 <section class="hero">
 	<img alt="{title} logotype" class="logotype" src={logotype}>
-	<h3>{tagline}</h3>
+	<p>{tagline}</p>
 </section>


### PR DESCRIPTION
This may be intentional 🤔 , but I think using a `<h3>` in the component `<Hero>` is a bit risky.
Depending on how it’s used it could break the headings structure and do not facilitate keyboard navigation by users of assistive technology.

This is the case on the [svelte.dev](https://svelte.dev/) homepage where a heading level is skipped with the usage of `<Hero>`.
Lighthouse reports an a11y issue :
![image](https://user-images.githubusercontent.com/6984856/106291993-96161c00-624c-11eb-9c27-6374b7707cc9.png)

This PR fixes this issue by replacing `h3` by `p`.

