### PR TITLE
blockquote style

### DIFF
--- a/packages/site-kit/src/lib/styles/text.css
+++ b/packages/site-kit/src/lib/styles/text.css
@@ -291,7 +291,7 @@
 	border: 1px solid var(--sk-theme-1);
 	border-radius: var(--sk-border-radius);
 	padding: 1rem;
-	filter: drop-shadow(0 0 6px hsla(15, 100%, 50%, 0.2));
+	filter: drop-shadow(2px 2px 6px hsla(15, 100%, 50%, 0.2));
 }
 
 .text blockquote :first-child {

--- a/packages/site-kit/src/lib/styles/text.css
+++ b/packages/site-kit/src/lib/styles/text.css
@@ -286,10 +286,12 @@
 }
 
 .text blockquote {
-	color: var(--sk-text-translucent);
-	background-color: rgba(255, 62, 0, 0.2);
-	border-left: 4px solid #ff3e00;
+	background: var(--sk-back-1);
+	color: var(--sk-text-1);
+	border: 1px solid var(--sk-theme-1);
+	border-radius: var(--sk-border-radius);
 	padding: 1rem;
+	filter: drop-shadow(0 0 6px hsla(15, 100%, 50%, 0.2));
 }
 
 .text blockquote :first-child {
@@ -298,15 +300,6 @@
 
 .text blockquote :last-child {
 	margin-bottom: 0;
-}
-
-.text blockquote code {
-	background: var(--sk-back-translucent);
-	color: var(--sk-text-1);
-}
-
-.text blockquote pre code {
-	background: transparent;
 }
 
 .text section a:hover {


### PR DESCRIPTION
taking another crack at blockquote styles. i don't hate this one. it uses an existing theme colour, it's easily distinguishable from `<pre>` blocks etc, it can accommodate any content without a11y problems because it has a white background, etc

<img width="712" alt="image" src="https://user-images.githubusercontent.com/1162160/207205693-c7ccdd4e-0da9-40c3-a405-ad74c387ac88.png">

<img width="718" alt="image" src="https://user-images.githubusercontent.com/1162160/207205671-3f540e02-b934-4e5c-9be8-d9aa16078174.png">

<img width="452" alt="image" src="https://user-images.githubusercontent.com/1162160/207205725-afd392fd-bfd5-4c4d-bf04-e6dd813c8b1e.png">
