### PR TITLE
Update SkipLink.svelte

### DIFF
--- a/packages/site-kit/src/lib/components/SkipLink.svelte
+++ b/packages/site-kit/src/lib/components/SkipLink.svelte
@@ -15,9 +15,11 @@
 		inset-inline-start: 0;
 		transform: translateY(-999px);
 		z-index: 1000; /* 1 more than the banner z-index */
+		opacity: 0;
 	}
 
 	a:focus {
 		transform: translateY(0%);
+		opacity: 1;
 	}
 </style>


### PR DESCRIPTION
SkipLink border is visible at all times (150% windows scaling), and also visible on overscroll in Microsoft Edge (using mousepads and touchscreen devices running Windows)