### PR TITLE
chore: add IME support for SearchBox

### DIFF
--- a/.changeset/mean-spies-worry.md
+++ b/.changeset/mean-spies-worry.md
@@ -2,4 +2,4 @@
 "@sveltejs/site-kit": patch
 ---
 
-chore: Add IME support for SearchBox
+chore: add IME support for SearchBox

--- a/.changeset/mean-spies-worry.md
+++ b/.changeset/mean-spies-worry.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/site-kit": patch
+---
+
+chore: Add IME support for SearchBox

--- a/packages/site-kit/src/lib/search/SearchBox.svelte
+++ b/packages/site-kit/src/lib/search/SearchBox.svelte
@@ -144,7 +144,7 @@ It appears when the user clicks on the `Search` component or presses the corresp
 			<input
 				autofocus
 				on:keydown={(e) => {
-					if (e.key === 'Enter') {
+					if (e.key === 'Enter' && !e.isComposing) {
 						/** @type {HTMLElement | undefined} */ (
 							modal.querySelector('a[data-has-node]')
 						)?.click();


### PR DESCRIPTION
I came across a issue about IME, in the SearchBox.
For more information about IME and KeyboardEvent, please see this article:
- https://developer.squareup.com/blog/understanding-composition-browser-events/

I understand that this PR is not necessary for the official English site, but I believe this will be helpful for other language site in the future, and should not affect users who do not use an IME.
