### PR TITLE
svelte-local-storage-store needs to be a dependency not a devDependency

### DIFF
--- a/.changeset/forty-moons-prove.md
+++ b/.changeset/forty-moons-prove.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/site-kit': major
+---
+
+fix: install svelte-local-storage-store as dependency

--- a/packages/site-kit/package.json
+++ b/packages/site-kit/package.json
@@ -24,9 +24,11 @@
 		"@sveltejs/package": "^1.0.2",
 		"flexsearch": "^0.7.31",
 		"svelte": "^3.55.1",
-		"svelte-local-storage-store": "^0.4.0",
 		"typescript": "^4.9.5",
 		"vite": "^4.0.4"
+	},
+	"dependencies": {
+		"svelte-local-storage-store": "^0.4.0"
 	},
 	"publishConfig": {
 		"access": "public",


### PR DESCRIPTION
installing this on learn.svelte.dev failed due to missing dependency