### PR TITLE
fix: Don't hide nav home title on small screen

### DIFF
--- a/.changeset/curvy-trainers-tan.md
+++ b/.changeset/curvy-trainers-tan.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/site-kit': patch
+---
+
+Fix: Don't hide navbar's home text label

--- a/packages/site-kit/src/lib/components/Nav.svelte
+++ b/packages/site-kit/src/lib/components/Nav.svelte
@@ -246,10 +246,6 @@ Top navigation bar for the application. It provides a slot for the left side, th
 		.appearance .caption {
 			display: block;
 		}
-
-		.home :global(span :not(strong)) {
-			display: none;
-		}
 	}
 
 	@media (min-width: 800px) {


### PR DESCRIPTION
.svelte.dev isn't hidden anymore on small screens

<img width="599" alt="CleanShot 2023-04-11 at 23 03 20@2x" src="https://user-images.githubusercontent.com/47742487/231243291-009ab384-eecf-4a30-bbbb-747a1fc27956.png">
