### PR TITLE
Fix nav

### DIFF
--- a/.changeset/twenty-queens-talk.md
+++ b/.changeset/twenty-queens-talk.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/site-kit': patch
+---
+
+allow nav to scroll, fix JS/TS toggle position

--- a/packages/site-kit/src/lib/components/Shell.svelte
+++ b/packages/site-kit/src/lib/components/Shell.svelte
@@ -59,6 +59,7 @@ The main shell of the application. It provides a slot for the top navigation, th
 
 		background: hsla(0, 0%, 0%, 0.1);
 		backdrop-filter: blur(2px);
+		-webkit-backdrop-filter: blur(2px);
 
 		transition: opacity 0.4s cubic-bezier(0.23, 1, 0.32, 1);
 	}

--- a/packages/site-kit/src/lib/docs/DocsContents.svelte
+++ b/packages/site-kit/src/lib/docs/DocsContents.svelte
@@ -106,15 +106,15 @@
 	}
 
 	.ts-toggle {
-		position: sticky;
+		position: fixed;
 		width: var(--sidebar-width);
-		bottom: calc(-1 * var(--ts-toggle-height));
+		bottom: 0;
 		left: 0;
 		z-index: 1;
 		margin-right: 0;
+		border-top: 1px solid var(--sk-back-4);
 		border-right: 1px solid var(--sk-back-5);
 		background-color: var(--sk-back-3);
-		box-shadow: 0 -0.1px 6px 0.9px hsla(0, 0%, 0%, 0.1);
 	}
 
 	@media (max-width: 831px) {

--- a/packages/site-kit/src/lib/docs/DocsContents.svelte
+++ b/packages/site-kit/src/lib/docs/DocsContents.svelte
@@ -33,13 +33,13 @@
 			</li>
 		{/each}
 	</ul>
-
-	{#if show_ts_toggle}
-		<div class="ts-toggle">
-			<TSToggle />
-		</div>
-	{/if}
 </nav>
+
+{#if show_ts_toggle}
+	<div class="ts-toggle">
+		<TSToggle />
+	</div>
+{/if}
 
 <style>
 	nav {
@@ -108,7 +108,7 @@
 	.ts-toggle {
 		position: sticky;
 		width: var(--sidebar-width);
-		bottom: 0;
+		bottom: calc(-1 * var(--ts-toggle-height));
 		left: 0;
 		z-index: 1;
 		margin-right: 0;
@@ -160,7 +160,9 @@
 		}
 
 		nav {
-			min-height: calc(100vh - var(--ts-toggle-height));
+			max-height: calc(100vh - var(--ts-toggle-height) - var(--sk-nav-height));
+			overflow-x: hidden;
+			overflow-y: auto;
 		}
 
 		.active::after {

--- a/packages/site-kit/src/lib/nav/Nav.svelte
+++ b/packages/site-kit/src/lib/nav/Nav.svelte
@@ -193,6 +193,26 @@ Top navigation bar for the application. It provides a slot for the left side, th
 					class="viewport"
 					bind:clientHeight={menu_height}
 					style="--height-difference: {menu_height - universal_menu_inner_height + 'px'}"
+					on:transitionstart|self={(e) => {
+						if (e.propertyName === 'transform') {
+							// we need to apply a clip-path during the transition so that the contents
+							// are constrained to the menu background, but only while the transition
+							// is running, otherwise it prevents the contents from being scrolled
+							const universal = `polygon(0 var(--height-difference), 50% var(--height-difference), 50% 100%, 0 100%)`;
+							const contextual = `polygon(50% 0, 100% 0, 100% 100%, 50% 100%)`;
+
+							const viewport = e.currentTarget;
+
+							viewport.style.clipPath = $current_menu_view ? universal : contextual;
+
+							setTimeout(() => {
+								viewport.style.clipPath = $current_menu_view ? contextual : universal;
+							}, 0);
+						}
+					}}
+					on:transitionend|self={(e) => {
+						e.currentTarget.style.clipPath = '';
+					}}
 				>
 					<div class="universal">
 						<ul bind:clientHeight={universal_menu_inner_height}>
@@ -476,12 +496,6 @@ Top navigation bar for the application. It provides a slot for the left side, th
 			grid-template-columns: 50% 50%;
 			transition: all 0.4s cubic-bezier(0.23, 1, 0.32, 1);
 			grid-auto-rows: 100%;
-			clip-path: polygon(
-				0 var(--height-difference),
-				50% var(--height-difference),
-				50% 100%,
-				0 100%
-			);
 		}
 
 		.mobile-main-menu.reduced-motion .viewport {
@@ -490,7 +504,6 @@ Top navigation bar for the application. It provides a slot for the left side, th
 
 		.mobile-main-menu.offset .viewport {
 			transform: translate3d(-50%, 0, 0);
-			clip-path: polygon(50% 0, 100% 0, 100% 100%, 50% 100%);
 		}
 
 		.mobile-main-menu .universal ul {

--- a/packages/site-kit/src/lib/nav/Nav.svelte
+++ b/packages/site-kit/src/lib/nav/Nav.svelte
@@ -190,53 +190,65 @@ Top navigation bar for the application. It provides a slot for the left side, th
 				/>
 
 				<div
-					class="viewport"
-					bind:clientHeight={menu_height}
-					style="--height-difference: {menu_height - universal_menu_inner_height + 'px'}"
-					on:transitionstart|self={(e) => {
-						if (e.propertyName === 'transform') {
-							// we need to apply a clip-path during the transition so that the contents
-							// are constrained to the menu background, but only while the transition
-							// is running, otherwise it prevents the contents from being scrolled
-							const universal = `polygon(0 var(--height-difference), 50% var(--height-difference), 50% 100%, 0 100%)`;
-							const contextual = `polygon(50% 0, 100% 0, 100% 100%, 50% 100%)`;
+					class="clip"
+					style:--height-difference="{menu_height - universal_menu_inner_height}px"
+					on:transitionstart={(e) => {
+						const target = /** @type {HTMLElement} */ (e.target);
 
-							const viewport = e.currentTarget;
+						if (!target?.classList.contains('viewport')) return;
+						if (e.propertyName !== 'transform') return;
 
-							viewport.style.clipPath = $current_menu_view ? universal : contextual;
+						// we need to apply a clip-path during the transition so that the contents
+						// are constrained to the menu background, but only while the transition
+						// is running, otherwise it prevents the contents from being scrolled
+						const a = 'calc(var(--height-difference) + 10px)';
+						const b = '10px';
 
-							setTimeout(() => {
-								viewport.style.clipPath = $current_menu_view ? contextual : universal;
-							}, 0);
-						}
+						const start = $current_menu_view ? a : b;
+						const end = $current_menu_view ? b : a;
+
+						const container = e.currentTarget;
+
+						container.style.clipPath = `polygon(0% ${start}, 100% ${start}, 100% 100%, 0% 100%)`;
+
+						setTimeout(() => {
+							container.style.clipPath = `polygon(0% ${end}, 100% ${end}, 100% 100%, 0% 100%)`;
+						}, 0);
 					}}
-					on:transitionend|self={(e) => {
+					on:transitionend={(e) => {
+						const target = /** @type {HTMLElement} */ (e.target);
+
+						if (!target?.classList.contains('viewport')) return;
+						if (e.propertyName !== 'transform') return;
+
 						e.currentTarget.style.clipPath = '';
 					}}
 				>
-					<div class="universal">
-						<div class="contents" bind:clientHeight={universal_menu_inner_height}>
-							<ul>
-								<slot name="nav-right" />
-							</ul>
-							<Separator linear />
-							<div style="height: 1rem" />
-							<Search />
-							<div class="appearance">
-								<span class="caption">Theme</span>
-								<ThemeToggle />
+					<div class="viewport" bind:clientHeight={menu_height}>
+						<div class="universal">
+							<div class="contents" bind:clientHeight={universal_menu_inner_height}>
+								<ul>
+									<slot name="nav-right" />
+								</ul>
+								<Separator linear />
+								<div style="height: 1rem" />
+								<Search />
+								<div class="appearance">
+									<span class="caption">Theme</span>
+									<ThemeToggle />
+								</div>
 							</div>
 						</div>
-					</div>
 
-					<div class="context">
-						<NavContextMenu bind:this={nav_context_instance} contents={context_menu_content} />
-					</div>
+						<div class="context">
+							<NavContextMenu bind:this={nav_context_instance} contents={context_menu_content} />
+						</div>
 
-					<button class="back-button" on:click={() => ($current_menu_view = null)}>
-						<Icon name="arrow-left" size=".6em" />
-						<span>Back to main menu</span>
-					</button>
+						<button class="back-button" on:click={() => ($current_menu_view = null)}>
+							<Icon name="arrow-left" size=".6em" />
+							<span>Back to main menu</span>
+						</button>
+					</div>
 				</div>
 			</div>
 		</Menu>
@@ -487,13 +499,19 @@ Top navigation bar for the application. It provides a slot for the left side, th
 			height: 100%;
 		}
 
+		.mobile-main-menu .clip {
+			width: 100%;
+			height: 100%;
+			transition: clip-path 0.4s cubic-bezier(0.23, 1, 0.32, 1);
+		}
+
 		.mobile-main-menu .viewport {
 			position: relative;
 			display: grid;
 			width: 200%;
 			height: 100%;
 			grid-template-columns: 50% 50%;
-			transition: all 0.4s cubic-bezier(0.23, 1, 0.32, 1);
+			transition: transform 0.4s cubic-bezier(0.23, 1, 0.32, 1);
 			grid-auto-rows: 100%;
 		}
 
@@ -511,7 +529,6 @@ Top navigation bar for the application. It provides a slot for the left side, th
 			bottom: 0;
 			padding: 1rem;
 			max-height: 70vh;
-			height: 100%;
 			overflow-y: scroll;
 		}
 

--- a/packages/site-kit/src/lib/nav/Nav.svelte
+++ b/packages/site-kit/src/lib/nav/Nav.svelte
@@ -215,18 +215,18 @@ Top navigation bar for the application. It provides a slot for the left side, th
 					}}
 				>
 					<div class="universal">
-						<ul bind:clientHeight={universal_menu_inner_height}>
-							<slot name="nav-right" />
-							<Separator />
+						<div class="contents" bind:clientHeight={universal_menu_inner_height}>
+							<ul>
+								<slot name="nav-right" />
+							</ul>
+							<Separator linear />
 							<div style="height: 1rem" />
 							<Search />
-							<li class="appearance">
-								<div>
-									<span class="caption">Theme</span>
-									<ThemeToggle />
-								</div>
-							</li>
-						</ul>
+							<div class="appearance">
+								<span class="caption">Theme</span>
+								<ThemeToggle />
+							</div>
+						</div>
 					</div>
 
 					<div class="context">
@@ -388,7 +388,6 @@ Top navigation bar for the application. It provides a slot for the left side, th
 
 	.appearance {
 		display: flex;
-		height: 100%;
 		align-items: center;
 		margin-left: 0.75rem;
 	}
@@ -506,11 +505,14 @@ Top navigation bar for the application. It provides a slot for the left side, th
 			transform: translate3d(-50%, 0, 0);
 		}
 
-		.mobile-main-menu .universal ul {
+		.mobile-main-menu .universal .contents {
 			position: absolute;
 			width: 50%;
 			bottom: 0;
 			padding: 1rem;
+			max-height: 70vh;
+			height: 100%;
+			overflow-y: scroll;
 		}
 
 		.mobile-main-menu.offset .context {
@@ -586,22 +588,11 @@ Top navigation bar for the application. It provides a slot for the left side, th
 			position: relative;
 			left: -1.25rem;
 			bottom: -1rem;
-
 			display: flex;
-			flex-direction: column;
 			gap: 2rem;
-
 			padding: 1.5rem 1.25rem;
-
-			width: calc(100% + 1.25rem);
-		}
-
-		.appearance > div {
-			display: flex;
-			align-items: center;
 			justify-content: space-between;
-
-			width: calc(100%);
+			width: calc(100% + 1.25rem);
 		}
 
 		.appearance .caption {
@@ -622,6 +613,7 @@ Top navigation bar for the application. It provides a slot for the left side, th
 			display: flex;
 			width: auto;
 			height: 100%;
+			align-items: center;
 		}
 
 		ul :global(li) {

--- a/packages/site-kit/src/lib/search/Search.svelte
+++ b/packages/site-kit/src/lib/search/Search.svelte
@@ -47,7 +47,6 @@ Renders a search widget which when clicked (or the corresponding keyboard shortc
 		display: flex;
 		align-items: center;
 		width: 100%;
-		height: 100%;
 	}
 
 	input {


### PR DESCRIPTION
This fixes the floating JS/TS toggle, and only applies `clip-path` during the context menu transition.

Still to do: ensure that the main menu is scrollable, on small enough screens