### PR TITLE
remove $page.data stuff

### DIFF
--- a/.changeset/hungry-moons-dance.md
+++ b/.changeset/hungry-moons-dance.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/site-kit': patch
+---
+
+require props to be set on <Nav> instead of reading $page.data

--- a/packages/site-kit/package.json
+++ b/packages/site-kit/package.json
@@ -37,7 +37,11 @@
 		"@sveltejs/kit": "^1.0.0",
 		"svelte": "^3.54.0 || ^4.0.0-next.0 || ^4.0.0"
 	},
+	"types": "./dist/types.d.ts",
 	"exports": {
+		".": {
+			"types": "./dist/types.d.ts"
+		},
 		"./actions": {
 			"types": "./dist/actions/index.d.ts",
 			"default": "./dist/actions/index.js"

--- a/packages/site-kit/src/lib/nav/Nav.svelte
+++ b/packages/site-kit/src/lib/nav/Nav.svelte
@@ -9,7 +9,7 @@ Top navigation bar for the application. It provides a slot for the left side, th
 	import { Search } from '$lib/search';
 	import { overlay_open, reduced_motion, searching, theme } from '$lib/stores';
 	import { onMount } from 'svelte';
-	import { circOut, expoOut, quintOut, sineOut } from 'svelte/easing';
+	import { expoOut, quintOut } from 'svelte/easing';
 	import { writable } from 'svelte/store';
 	import Icon from '../components/Icon.svelte';
 	import ThemeToggle from '../components/ThemeToggle.svelte';
@@ -19,6 +19,12 @@ Top navigation bar for the application. It provides a slot for the left side, th
 	import { set_nav_context } from './nav.context';
 
 	export let home_title = 'Homepage';
+
+	/** @type {string | undefined} */
+	export let title;
+
+	/** @type {import('../types').Menu} */
+	export let menu;
 
 	/** @type {import('svelte/store').Writable<string | null>} */
 	const current_menu_view = writable(null);
@@ -34,13 +40,13 @@ Top navigation bar for the application. It provides a slot for the left side, th
 		context_menu = /** @type {string} */ ($current_menu_view ?? $page_selected);
 	}
 
-	$: context_menu_content = $page.data.nav_context_list[context_menu];
+	$: context_menu_content = menu[context_menu];
 
 	/** @type {NavContextMenu} */
 	let nav_context_instance;
 
 	let open = false;
-	let visible = $page.data.nav_initially_visible ?? true;
+	let visible = true;
 
 	/** @type {HTMLElement} */
 	let nav;
@@ -153,9 +159,9 @@ Top navigation bar for the application. It provides a slot for the left side, th
 			<slot name="home-small" />
 		</span>
 
-		{#if $page.data.nav_title}
+		{#if title}
 			<div class="nav-title">
-				{$page.data.nav_title}
+				{title}
 			</div>
 		{/if}
 	</a>

--- a/packages/site-kit/src/lib/types.d.ts
+++ b/packages/site-kit/src/lib/types.d.ts
@@ -1,0 +1,10 @@
+export interface Section {
+	title: string;
+	sections: {
+		title: string;
+		path: string;
+		badge?: string;
+	}[];
+}
+
+export type Menu = Record<string, Section[]>;


### PR DESCRIPTION
We should use props on `<Nav>` rather than `$page.data` — it's much easier to understand why things aren't working if the typechecker can point you to the right place.

I don't know if this is the right structure or not though — part of me thinks we should get rid of `<NavItem>` for internal links, and use `menu` to drive that instead