### PR TITLE
fix: Clicking on context menu arrow throw erros

### DIFF
--- a/.changeset/unlucky-cougars-trade.md
+++ b/.changeset/unlucky-cougars-trade.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/site-kit': patch
+---
+
+Fix clicking on context menu arrow throws error

--- a/packages/site-kit/src/lib/nav/Menu.svelte
+++ b/packages/site-kit/src/lib/nav/Menu.svelte
@@ -6,6 +6,7 @@
 	import Icon from '../components/Icon.svelte';
 	import NavContextMenu from './NavContextMenu.svelte';
 	import { page } from '$app/stores';
+	import { tick } from 'svelte';
 
 	/** @type {boolean} */
 	export let open;
@@ -162,8 +163,11 @@
 										{#if link.sections}
 											<button
 												class="related-menu-arrow"
-												on:click|preventDefault={() => {
+												on:click|preventDefault={async () => {
 													current_menu_view = link;
+
+													await tick();
+
 													nav_context_instance.reset();
 													show_context_menu = true;
 												}}

--- a/packages/site-kit/src/lib/nav/Menu.svelte
+++ b/packages/site-kit/src/lib/nav/Menu.svelte
@@ -1,12 +1,12 @@
 <script>
-	import { expoOut, quintOut } from 'svelte/easing';
 	import { afterNavigate } from '$app/navigation';
+	import { page } from '$app/stores';
 	import { click_outside, focus_outside, trap } from '$lib/actions';
 	import { overlay_open, reduced_motion, theme } from '$lib/stores';
+	import { tick } from 'svelte';
+	import { expoOut, quintOut } from 'svelte/easing';
 	import Icon from '../components/Icon.svelte';
 	import NavContextMenu from './NavContextMenu.svelte';
-	import { page } from '$app/stores';
-	import { tick } from 'svelte';
 
 	/** @type {boolean} */
 	export let open;


### PR DESCRIPTION
Fixed by waiting for NavContextMenu to be created, with `await tick()`;