### PR TITLE
Improve a11y of new site design

### DIFF
--- a/packages/site-kit/src/lib/actions/focus.js
+++ b/packages/site-kit/src/lib/actions/focus.js
@@ -44,7 +44,7 @@ export function focusable_children(node) {
 	};
 }
 
-export function trap(node) {
+export function trap(node, { reset_focus = true }) {
 	const previous = /** @type HTMLElement} */ (document.activeElement);
 
 	const handle_keydown = (e) => {
@@ -65,7 +65,9 @@ export function trap(node) {
 	return {
 		destroy: () => {
 			node.removeEventListener('keydown', handle_keydown);
-			previous?.focus({ preventScroll: true });
+			if (reset_focus) {
+				previous?.focus({ preventScroll: true });
+			}
 		}
 	};
 }

--- a/packages/site-kit/src/lib/docs/DocsOnThisPage.svelte
+++ b/packages/site-kit/src/lib/docs/DocsOnThisPage.svelte
@@ -116,7 +116,7 @@
 
 <aside class="on-this-page" bind:this={containerEl}>
 	<h2>On this page</h2>
-	<nav>
+	<nav aria-label="On this page">
 		<ul>
 			<li>
 				<a

--- a/packages/site-kit/src/lib/nav/Menu.svelte
+++ b/packages/site-kit/src/lib/nav/Menu.svelte
@@ -25,6 +25,12 @@
 	let ready = false;
 	let show_context_menu = false;
 
+	/** @type {HTMLElement} */
+	let universal_menu;
+
+	/** @type {HTMLElement} */
+	let context_menu;
+
 	function close() {
 		open = false;
 	}
@@ -146,6 +152,13 @@
 						if (e.propertyName !== 'transform') return;
 
 						e.currentTarget.style.clipPath = '';
+
+						// whenever we transition from one menu to the other, we need to move focus to the first item in the new menu
+						if (show_context_menu) {
+							context_menu.querySelector('a')?.focus();
+						} else {
+							universal_menu.querySelector('a')?.focus();
+						}
 					}}
 				>
 					<div
@@ -154,7 +167,7 @@
 						class:offset={show_context_menu}
 						bind:clientHeight={menu_height}
 					>
-						<div class="universal" inert={show_context_menu}>
+						<div class="universal" inert={show_context_menu} bind:this={universal_menu}>
 							<div class="contents" bind:clientHeight={universal_menu_inner_height}>
 								{#each links as link}
 									<a href={link.pathname}>
@@ -182,7 +195,7 @@
 							</div>
 						</div>
 
-						<div class="context" inert={!show_context_menu}>
+						<div class="context" inert={!show_context_menu} bind:this={context_menu}>
 							{#if current_menu_view}
 								<NavContextMenu
 									bind:this={nav_context_instance}

--- a/packages/site-kit/src/lib/nav/Menu.svelte
+++ b/packages/site-kit/src/lib/nav/Menu.svelte
@@ -394,7 +394,6 @@
 	.related-menu-arrow:hover {
 		border-radius: var(--sk-border-radius);
 
-		color: initial;
 		text-decoration: none;
 
 		background-color: var(--sk-back-4);

--- a/packages/site-kit/src/lib/nav/Menu.svelte
+++ b/packages/site-kit/src/lib/nav/Menu.svelte
@@ -108,7 +108,7 @@
 	</button>
 
 	{#if open}
-		<div class="menu" use:trap>
+		<div class="menu" use:trap={{ reset_focus: false }}>
 			<div class="mobile-main-menu" in:slide out:slide={{ duration: 500, easing: quintOut }}>
 				<div
 					class="menu-background"

--- a/packages/site-kit/src/lib/nav/Menu.svelte
+++ b/packages/site-kit/src/lib/nav/Menu.svelte
@@ -170,9 +170,10 @@
 						<div class="universal" inert={show_context_menu} bind:this={universal_menu}>
 							<div class="contents" bind:clientHeight={universal_menu_inner_height}>
 								{#each links as link}
-									<a href={link.pathname}>
-										{link.title}
-
+									<div class="link-item">
+										<a href={link.pathname}>
+											{link.title}
+										</a>
 										{#if link.sections}
 											<button
 												class="related-menu-arrow"
@@ -184,11 +185,12 @@
 													nav_context_instance.reset();
 													show_context_menu = true;
 												}}
+												aria-label="Show {link.title} submenu"
 											>
 												<Icon name="arrow-right-chevron" size="6rem" />
 											</button>
 										{/if}
-									</a>
+									</div>
 								{/each}
 
 								<slot />
@@ -356,19 +358,21 @@
 		pointer-events: all;
 	}
 
-	.universal :global(a) {
+	.universal .link-item {
+		--button-width: 4rem;
 		position: relative;
+		padding-right: var(--button-width);
 	}
 
-	.universal .contents :global(a button) {
+	.universal .contents .link-item button {
 		position: absolute;
 		right: 0;
 		top: 0;
-		width: 4rem;
+		width: var(--button-width);
 		height: 100%;
 	}
 
-	.viewport :global(a svg) {
+	.viewport .link-item :global(svg) {
 		stroke-width: 0;
 	}
 
@@ -385,7 +389,8 @@
 		background-color: hsla(var(--sk-theme-1-hsl), 0.05);
 	}
 
-	.viewport :global(a:hover) {
+	.viewport :global(a:hover),
+	.related-menu-arrow:hover {
 		border-radius: var(--sk-border-radius);
 
 		color: initial;

--- a/packages/site-kit/src/lib/nav/Menu.svelte
+++ b/packages/site-kit/src/lib/nav/Menu.svelte
@@ -289,7 +289,8 @@
 	}
 
 	.viewport.reduced-motion {
-		transition: none;
+		/* we still want the transition events to fire for focus management */
+		transition-duration: 0.01ms;
 	}
 
 	.viewport.offset {

--- a/packages/site-kit/src/lib/nav/Menu.svelte
+++ b/packages/site-kit/src/lib/nav/Menu.svelte
@@ -31,6 +31,9 @@
 	/** @type {HTMLElement} */
 	let context_menu;
 
+	/** @type {HTMLButtonElement} */
+	let menu_button;
+
 	function close() {
 		open = false;
 	}
@@ -82,6 +85,9 @@
 	on:keydown={(e) => {
 		if (e.key === 'Escape') {
 			close();
+			// we only manage focus when Esc is hit
+			// otherwise, the navigation will reset focus
+			tick().then(() => menu_button.focus());
 		}
 	}}
 />
@@ -92,6 +98,7 @@
 		aria-expanded={open}
 		class="menu-toggle"
 		class:open
+		bind:this={menu_button}
 		on:click={() => {
 			if (open) {
 				close();

--- a/packages/site-kit/src/lib/nav/Nav.svelte
+++ b/packages/site-kit/src/lib/nav/Nav.svelte
@@ -160,7 +160,7 @@ Top navigation bar for the application. It provides a slot for the left side, th
 	}
 
 	@media (max-width: 800px) {
-		nav:not(.visible) {
+		nav:not(.visible):not(:focus-within) {
 			transform: translate(0, calc(var(--sk-nav-height)));
 		}
 	}


### PR DESCRIPTION
This PR is a bunch of improvements for a11y and the new site. Summary of changes:

## Manage focus when changing submenus in the mobile nav

Focus wasn't being set when swapping between submenus (e.g. the main menu and the docs sub menu) so it was getting lost, since the outroing menu becomes inert. I manually focused the first link in whatever menu was becoming available. This had to happen in a transitionend event; otherwise, focus moved too soon and it caused some animation glitches.

So that this focus management also works when reduced motion is enabled, instead of disabling transitions completely for reduced motion I set a very low transition duration.

## Prevent nav from hiding when it has focus

The mobile nav could receive keyboard focus but not show, since that's triggered on scroll. I updated the CSS to also show the nav if focus is inside it.

## Don't nest button inside link

It's invalid to nest interactive elements and can cause accessibility problems. This was happening on each menu item with a sub menu:

<img width="514" alt="image" src="https://github.com/sveltejs/site-kit/assets/4992896/a2e27ba4-f16d-46cf-b0a3-d20f1aff51d8">

I refactored the markup to separate the button from the link. This required tweaking some styles - I didn't seem to break anything else with those changes, but let me know if there's something else I should take a look at. Some of the styles were global but appeared like they could be scoped instead.

## Fix focus management when navigating to a menu item in the mobile nav

If you triggered a link in the mobile nav, you would navigate to the new page but focus would be sent to the menu toggle. I tweaked the behavior so focus is only sent to the toggle when the menu is closed with Esc. Otherwise, the user triggered a navigation and would expect focus to be moved elsewhere.

## Other fixes

- Give the "on this page" nav a label
- Fix dark mode link hover styles - they were showing as black on grey (screenshot below)
<img width="541" alt="image" src="https://github.com/sveltejs/site-kit/assets/4992896/6d41c245-b638-4fc9-abf8-618b89c07e3e">
