### PR TITLE
Add chevron-up and chevron-down icons

### DIFF
--- a/.changeset/rare-crabs-bake.md
+++ b/.changeset/rare-crabs-bake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/site-kit': minor
+---
+
+Add chevron-up and chevron-down icons

--- a/packages/site-kit/src/lib/components/Icons.svelte
+++ b/packages/site-kit/src/lib/components/Icons.svelte
@@ -155,6 +155,14 @@ Provides a list of svg icons that can be referenced through the `Icon` component
 			<path d="M2,7 L12,17 L20,7" />
 		</symbol>
 
+		<symbol id="chevron-up" class="icon" viewBox="0 0 24 24">
+			<polyline points="18 15 12 9 6 15" />
+		</symbol>
+
+		<symbol id="chevron-down" class="icon" viewBox="0 0 24 24">
+			<polyline points="6 9 12 15 18 9" />
+		</symbol>
+
 		<symbol id="delete" class="icon" viewBox="0 0 24 24">
 			<path
 				fill="currentColor"


### PR DESCRIPTION
This adds two new icons (from [feather icons](https://feathericons.com/?query=chevron), since it seems we've gotten icons from there before). It's needed for some work I'm doing for https://github.com/sveltejs/sites/issues/494 (see also https://github.com/sveltejs/svelte/pull/8831)

<img width="323" alt="image" src="https://github.com/sveltejs/site-kit/assets/4992896/9a5a0636-4119-4cb9-803f-d9361b78c41a">
