### PR TITLE
feat: hide scrollbar in aside

### DIFF
--- a/.changeset/tiny-suns-tease.md
+++ b/.changeset/tiny-suns-tease.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/site-kit': patch
+---
+
+hide scrollbar in aside

--- a/packages/site-kit/src/lib/docs/DocsOnThisPage.svelte
+++ b/packages/site-kit/src/lib/docs/DocsOnThisPage.svelte
@@ -241,6 +241,10 @@
 		top: var(--sk-nav-height);
 		left: calc(100vw - (var(--sidebar-width)));
 		overflow-y: auto;
+		scrollbar-width: none;
+	}
+	.on-this-page::-webkit-scrollbar {
+		display: none;
 	}
 
 	.heading {


### PR DESCRIPTION
in the https://svelte.dev/docs/accessibility-warnings when the aside has long content, it will have 2 scrollbars visible when scrolling down: 1 for the page content, 1 for the aside.

this PR hides the scrollbar in aside