### PR TITLE
fix: prevent triggering "On this page" overlay on desktop

### DIFF
--- a/.changeset/pretty-eagles-march.md
+++ b/.changeset/pretty-eagles-march.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/site-kit': patch
+---
+
+Prevent triggering "On this page" overlay on desktop

--- a/packages/site-kit/src/lib/docs/DocsOnThisPage.svelte
+++ b/packages/site-kit/src/lib/docs/DocsOnThisPage.svelte
@@ -180,21 +180,18 @@
 	use:focus_outside={() => $is_mobile && ($on_this_page_open = false)}
 >
 	<h2>
-		{#if $is_mobile}
-			<button
-				class="heading"
-				aria-expanded={$on_this_page_open}
-				on:click={() => ($on_this_page_open = !$on_this_page_open)}
-			>
-				<span class="h2">On this page</span>
-
-				<span class="expand-icon" class:inverted={$on_this_page_open}>
-					<Icon name="chevron-down" />
-				</span>
-			</button>
-		{:else}
+		<button
+			class="heading"
+			aria-expanded={$on_this_page_open}
+			on:click={() => ($on_this_page_open = !$on_this_page_open)}
+		>
 			<span class="h2">On this page</span>
-		{/if}
+
+			<span class="expand-icon" class:inverted={$on_this_page_open}>
+				<Icon name="chevron-down" />
+			</span>
+		</button>
+		<span class="h2 desktop-only-heading">On this page</span>
 	</h2>
 
 	{#if (browser && !$is_mobile) || ($is_mobile && $on_this_page_open)}
@@ -248,16 +245,7 @@
 	}
 
 	.heading {
-		position: relative;
-
-		width: 100%;
-
-		display: grid;
-		align-items: center;
-		grid-template-columns: 1fr auto;
-		gap: 0.75rem;
-
-		padding: 0.75rem 0.75rem;
+		display: none;
 	}
 
 	h2 {
@@ -276,9 +264,11 @@
 		text-align: start;
 	}
 
-	.heading :global(svg) {
-		display: none;
+	.desktop-only-heading {
+		display: inline;
+	}
 
+	.heading :global(svg) {
 		transform: translateY(-1px);
 	}
 
@@ -352,7 +342,20 @@
 			--shadow: 0 0 0 1px var(--sk-back-4);
 		}
 
+		.desktop-only-heading {
+			display: none;
+		}
+
 		.heading {
+			position: relative;
+			width: 100%;
+
+			display: grid;
+			align-items: center;
+			grid-template-columns: 1fr auto;
+			gap: 0.75rem;
+			padding: 0.75rem 0.75rem;
+
 			z-index: 2;
 
 			box-shadow: var(--shadow);

--- a/packages/site-kit/src/lib/docs/DocsOnThisPage.svelte
+++ b/packages/site-kit/src/lib/docs/DocsOnThisPage.svelte
@@ -179,19 +179,23 @@
 	use:click_outside={() => $is_mobile && ($on_this_page_open = false)}
 	use:focus_outside={() => $is_mobile && ($on_this_page_open = false)}
 >
-	<!-- svelte-ignore a11y-no-static-element-interactions -->
-	<svelte:element
-		this={$is_mobile ? 'button' : 'div'}
-		class="heading"
-		aria-expanded={$on_this_page_open}
-		on:click={() => ($on_this_page_open = !$on_this_page_open)}
-	>
-		<span class="h2">On this page</span>
+	<h2>
+		{#if $is_mobile}
+			<button
+				class="heading"
+				aria-expanded={$on_this_page_open}
+				on:click={() => ($on_this_page_open = !$on_this_page_open)}
+			>
+				<span class="h2">On this page</span>
 
-		<span class="expand-icon" class:inverted={$on_this_page_open}>
-			<Icon name="chevron-down" />
-		</span>
-	</svelte:element>
+				<span class="expand-icon" class:inverted={$on_this_page_open}>
+					<Icon name="chevron-down" />
+				</span>
+			</button>
+		{:else}
+			<span class="h2">On this page</span>
+		{/if}
+	</h2>
 
 	{#if (browser && !$is_mobile) || ($is_mobile && $on_this_page_open)}
 		<nav
@@ -254,6 +258,12 @@
 		gap: 0.75rem;
 
 		padding: 0.75rem 0.75rem;
+	}
+
+	h2 {
+		/* override global styles */
+		margin: 0;
+		border: none;
 	}
 
 	.h2 {


### PR DESCRIPTION
The existing implementation of the "On this page" nav still attached the click handler on the desktop view, even though the element was no longer a toggle. This meant you could still click it and the screen would dim, without any way to un-dim the screen.

This PR makes it so we only render a button (and attach the click handler) on mobile screen widths. It also improves semantics by reinstating the "On this page" h2, allowing assistive tech users to skip to it via heading shortcuts.

Swapping between the button and static text is done with CSS to avoid FOUC.