### PR TITLE
fix: aside uses only the space required

### DIFF
--- a/packages/site-kit/src/lib/docs/DocsOnThisPage.svelte
+++ b/packages/site-kit/src/lib/docs/DocsOnThisPage.svelte
@@ -238,7 +238,7 @@
 		position: fixed;
 		padding: var(--sk-page-padding-top) var(--sk-page-padding-side) 0 0;
 		width: min(280px, calc(var(--sidebar-width) - var(--sk-page-padding-side)));
-		height: calc(100vh - var(--sk-nav-height) - var(--sk-page-padding-top));
+		height: max-content;
 		top: var(--sk-nav-height);
 		left: calc(100vw - (var(--sidebar-width)));
 		overflow-y: auto;


### PR DESCRIPTION
Currently, if moused over anywhere on the right side of the page in Svelte/Kit docs, specifically when an "On This Page" is present, you can't scroll the page. This PR addresses that by shrinking the "On This Page" to only occupy actual required height. You still can't scroll while moused over the actual element, but you get most of the right side of the page back.

A more "correct" fix would be to give the `<aside>` changed in the commit `position: sticky`, but that would require a more involved change that alters the layout -- and I assume there's a decent reason for the layout being the way it is. There's a [decent write up on Stack Overflow](https://stackoverflow.com/a/73143164)<sup>1</sup>.

<sup>1</sup> :pinching_hand: :salt: 