### PR TITLE
fix: forward searchbox no-result slot

### DIFF
--- a/.changeset/tasty-parents-chew.md
+++ b/.changeset/tasty-parents-chew.md
@@ -1,0 +1,7 @@
+---
+'@sveltejs/site-kit': patch
+---
+
+forward searchbox slot
+
+pick 2175c9d79 Apply 1 suggestion(s) to 1 file(s)

--- a/.changeset/tasty-parents-chew.md
+++ b/.changeset/tasty-parents-chew.md
@@ -3,5 +3,3 @@
 ---
 
 forward searchbox slot
-
-pick 2175c9d79 Apply 1 suggestion(s) to 1 file(s)

--- a/packages/site-kit/src/lib/search/SearchBox.svelte
+++ b/packages/site-kit/src/lib/search/SearchBox.svelte
@@ -188,7 +188,9 @@ It appears when the user clicks on the `Search` component or presses the corresp
 							on:select={(e) => {
 								navigate(e.detail.href);
 							}}
-						/>
+						>
+							<slot name="no-results">No results</slot>
+						</SearchResults>
 					</div>
 				{:else}
 					<h2 class="info" class:empty={recent_searches.length === 0}>


### PR DESCRIPTION
I could not test it (got `npm link` issues), but this seems right.