### PR TITLE
fix: searchbox no-results slot

### DIFF
--- a/.changeset/strange-clocks-join.md
+++ b/.changeset/strange-clocks-join.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/site-kit': patch
+---
+
+fix searchbox no-results slot forwarding

--- a/packages/site-kit/src/lib/search/SearchBox.svelte
+++ b/packages/site-kit/src/lib/search/SearchBox.svelte
@@ -189,7 +189,7 @@ It appears when the user clicks on the `Search` component or presses the corresp
 								navigate(e.detail.href);
 							}}
 						>
-							<slot name="no-results">No results</slot>
+							<slot name="no-results" slot="no-results">No results</slot>
 						</SearchResults>
 					</div>
 				{:else}


### PR DESCRIPTION
I am so sorry for the multiple PRs on this topic, this should have been done correctly from the start in #192 ...

I still could not test this properly, I'm still facing issues with linking my local `site-kit` package, it complains with `Cannot find module '@sveltejs/site-kit/components'`, probably because of the packaged architecture... maybe someone knows how i can make the linking working.