### PR TITLE
fix: Do not copy deleted lines

### DIFF
--- a/.changeset/healthy-badgers-flash.md
+++ b/.changeset/healthy-badgers-flash.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/site-kit": patch
+---
+
+fix: Do not copy deleted lines

--- a/packages/site-kit/src/lib/actions/copy-code-descendants.js
+++ b/packages/site-kit/src/lib/actions/copy-code-descendants.js
@@ -18,7 +18,17 @@ export const copy_code_descendants = (node) => {
 			// Exclude the ts-block properties and stuff
 			if (/ts-block/.test(parent_class)) continue;
 
-			const code = block.querySelector('code')?.innerText ?? '';
+			let code = '';
+			for (const node of block.querySelector('code')?.childNodes ?? []) {
+				if (node.nodeType === Node.ELEMENT_NODE) {
+					if (!(/** @type {HTMLElement} */ (node).classList.contains('deleted'))) {
+						code += node.textContent;
+					}
+				} else {
+					code += node.textContent;
+				}
+			}
+
 			if (!code) continue;
 
 			// This is to make sure that snippets with title get the button on their heading area


### PR DESCRIPTION
I thought that I didn’t want to delete deleted line manually.

Without this PR:
https://github.com/sveltejs/site-kit/assets/19153718/3c6452d8-f563-407b-b328-33997dc8414d

With this PR:
https://github.com/sveltejs/site-kit/assets/19153718/c38c6bac-6299-4819-b21c-2ec26692bd7d

(Oh I'm not sure why video preview doesn't exist...)

And can we cut a new release after merging this PR?
I want to apply this change to the Svelte5 preview site.
