### PR TITLE
fix: add margin to main content

### DIFF
--- a/packages/site-kit/src/lib/components/Shell.svelte
+++ b/packages/site-kit/src/lib/components/Shell.svelte
@@ -96,7 +96,7 @@ The main shell of the application. It provides a slot for the top navigation, th
 	main {
 		position: relative;
 		margin: 0 auto;
-		padding-top: var(--sk-nav-height);
+		margin-top: var(--sk-nav-height);
 		padding-bottom: var(--sk-banner-bottom-height);
 		overflow: hidden;
 		overflow-y: auto;


### PR DESCRIPTION
Replace padding for margin on the main content in order to prevent the scrollbar from being hidden behind the top nav.

The issue was originally described here: https://github.com/sveltejs/svelte/issues/9219#issue-1899595020