### PR TITLE
fix: home link vertical alignment

### DIFF
--- a/.changeset/cuddly-mails-sit.md
+++ b/.changeset/cuddly-mails-sit.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/site-kit': patch
+---
+
+fix: home link text alignment issue

--- a/packages/site-kit/src/lib/nav/Nav.svelte
+++ b/packages/site-kit/src/lib/nav/Nav.svelte
@@ -204,6 +204,7 @@ Top navigation bar for the application. It provides a slot for the left side, th
 		background-size: auto 70%;
 		align-items: center;
 		padding-left: calc(var(--sk-page-padding-side) + 4rem);
+		padding-top: 5px; /* fixes font offset */
 		text-decoration: none;
 		text-transform: uppercase;
 		letter-spacing: 0.05em;

--- a/packages/site-kit/src/lib/nav/Nav.svelte
+++ b/packages/site-kit/src/lib/nav/Nav.svelte
@@ -204,7 +204,7 @@ Top navigation bar for the application. It provides a slot for the left side, th
 		background-size: auto 70%;
 		align-items: center;
 		padding-left: calc(var(--sk-page-padding-side) + 4rem);
-		padding-top: 5px; /* fixes font offset */
+		padding-top: 5px; /* center vertically relative to logo */
 		text-decoration: none;
 		text-transform: uppercase;
 		letter-spacing: 0.05em;


### PR DESCRIPTION
closes #246 

Text will now be center aligened:

![image](https://github.com/sveltejs/site-kit/assets/30938967/9f3a986a-78ee-4807-8bd5-a68b04f17dad)
