### PR TITLE
feat: Time-bound banner

### DIFF
--- a/.changeset/clean-wombats-work.md
+++ b/.changeset/clean-wombats-work.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/site-kit': patch
+---
+
+feat: Time-bound banner

--- a/packages/site-kit/src/lib/components/Banner.svelte
+++ b/packages/site-kit/src/lib/components/Banner.svelte
@@ -1,3 +1,12 @@
+<script context="module">
+	/**
+	 * @typedef {'svelte.dev' | 'kit.svelte.dev' | 'learn.svelte.dev'} BannerScope
+	 * @typedef {(import('svelte').ComponentProps<import('./Banner.svelte').default> & {
+	 * content: string; scope?: BannerScope[]
+	 * })[]} BannerData
+	 */
+</script>
+
 <script>
 	import { browser } from '$app/environment';
 	import { onMount } from 'svelte';

--- a/packages/site-kit/src/lib/components/Banners.svelte
+++ b/packages/site-kit/src/lib/components/Banners.svelte
@@ -1,0 +1,33 @@
+<script context="module">
+	/**
+	 * Only to be used on non svelte.dev sites. Shouldn't be used inside svelte.dev codebase itself
+	 * @param {import('./Banner.svelte').BannerScope} scope
+	 * @param {import('@sveltejs/kit').RequestEvent['fetch']} fetch
+	 */
+	export async function fetchBanner(scope = 'svelte.dev', fetch) {
+		if (scope === 'svelte.dev') return fetch('/banner.json').then((r) => r.json());
+
+		const req = await fetch('https://svelte.dev/banner.json');
+		if (!req.ok) {
+			console.warn('There was an error fetching the banner data. Check svelte.dev/banner.json');
+			return [];
+		}
+
+		return /** @type {import('./Banner.svelte').BannerData} */ (await req.json()).filter(
+			(banner) => !banner.scope || banner.scope?.includes(scope)
+		);
+	}
+</script>
+
+<script>
+	import Banner from './Banner.svelte';
+
+	/** @type {import('./Banner.svelte').BannerData} */
+	export let data;
+</script>
+
+{#each data as { content, href, id, start, arrow, end }}
+	<Banner {id} start={new Date(start)} end={end ? new Date(end) : undefined} {arrow} {href}>
+		{@html content}
+	</Banner>
+{/each}

--- a/packages/site-kit/src/lib/components/Banners.svelte
+++ b/packages/site-kit/src/lib/components/Banners.svelte
@@ -3,6 +3,7 @@
 	 * Only to be used on non svelte.dev sites. Shouldn't be used inside svelte.dev codebase itself
 	 * @param {import('./Banner.svelte').BannerScope} scope
 	 * @param {import('@sveltejs/kit').RequestEvent['fetch']} fetch
+	 * @returns {Promise<import('./Banner.svelte').BannerData>}
 	 */
 	export async function fetchBanner(scope = 'svelte.dev', fetch) {
 		if (scope === 'svelte.dev') return fetch('/banner.json').then((r) => r.json());

--- a/packages/site-kit/src/lib/components/index.js
+++ b/packages/site-kit/src/lib/components/index.js
@@ -1,6 +1,6 @@
+export { default as Banners, fetchBanner } from './Banners.svelte';
 export { default as Icon } from './Icon.svelte';
 export { default as Icons } from './Icons.svelte';
 export { default as Section } from './Section.svelte';
 export { default as Shell } from './Shell.svelte';
 export { default as ThemeToggle } from './ThemeToggle.svelte';
-export { default as Banner } from './Banner.svelte';


### PR DESCRIPTION
This binds the banner to start and end times. it assumes the user knows what they are doing and they wont set start > end 😅

This allows having multiple banners in the code, all with their time. For eg, we can have 2 banners in the site code, one for "Join us for svelte summit" and one for "Svelte Summit talks are out now". They both will be bound to their time, hence we can show them subsequently without needing a subsequent PR at the right time. 

This also allows us to set and forget them completely, until the next event comes up. This will avoid the awkward situation where the banner says "Join us on November 12" and the current date is December 1