### PR TITLE
chore: Refactor banner, stricter

### DIFF
--- a/.changeset/curly-lemons-care.md
+++ b/.changeset/curly-lemons-care.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/site-kit': minor
+---
+
+feat: Safer banners implementation, defineBanners, refactor

--- a/packages/site-kit/src/lib/components/Banner.svelte
+++ b/packages/site-kit/src/lib/components/Banner.svelte
@@ -1,26 +1,5 @@
-<script context="module">
-	/**
-	 * @typedef {'svelte.dev' | 'kit.svelte.dev' | 'learn.svelte.dev'} BannerScope
-	 * @typedef {{
-	 * id: string;
-	 * start: Date,
-	 * end?: Date,
-	 * arrow: boolean,
-	 * href: string;
-	 * content: string;
-	 * scope?: BannerScope[];
-	 * }[]} BannerData
-	 */
-
-	export const preferences = persisted(
-		'svelte:banner-preferences',
-		/** @type {Record<string, boolean>} */ ({})
-	);
-</script>
-
 <script>
-	import { onMount } from 'svelte';
-	import { persisted } from 'svelte-local-storage-store';
+	import { createEventDispatcher, onMount } from 'svelte';
 	import { quintOut } from 'svelte/easing';
 	import { fade } from 'svelte/transition';
 	import Icon from './Icon.svelte';
@@ -28,18 +7,14 @@
 	/** Whether to show an arrow at the end */
 	export let arrow = false;
 
-	/** Required for dismissing behavior e.g `<Banner id="svelte-5-runes" />` will make sure the banner
-	 * hidden only for this ID. Later if another banner is added, that will be visible by default.
-	 *
-	 * @type {string}
-	 */
-	export let id;
-
 	/**
 	 * Link to the event. It must be an absolute path (https://svelte.dev/blog/runes instead of /blog/runes)
 	 * @type {string}
 	 */
 	export let href;
+
+	/** @type {import('svelte').EventDispatcher<{ close: undefined }>} */
+	const dispatch = createEventDispatcher();
 
 	let show = false;
 	onMount(() => {
@@ -61,7 +36,7 @@
 			{/if}
 		</div>
 
-		<button class="close-button" on:click={() => ($preferences[id] = false)}>
+		<button class="close-button" on:click={() => dispatch('close')}>
 			<Icon name="close" />
 		</button>
 	</div>

--- a/packages/site-kit/src/lib/components/Banners.svelte
+++ b/packages/site-kit/src/lib/components/Banners.svelte
@@ -21,14 +21,36 @@
 </script>
 
 <script>
-	import Banner from './Banner.svelte';
+	import { browser } from '$app/environment';
+	import { onMount } from 'svelte';
+	import Banner, { preferences } from './Banner.svelte';
 
 	/** @type {import('./Banner.svelte').BannerData} */
 	export let data;
+
+	const time = new Date();
+
+	$: showing = data.filter(
+		({ id, start, end }) =>
+			$preferences[id] && time > new Date(start) && time < new Date(end ?? new Date(2123, 12, 1))
+	);
+
+	$: if (browser) {
+		document.documentElement.style.setProperty(
+			'--sk-banner-bottom-height',
+			showing.length * 43 + 'px'
+		);
+	}
+
+	onMount(() => {
+		for (const { id } of data) {
+			$preferences[id] ??= true;
+		}
+	});
 </script>
 
-{#each data as { content, href, id, start, arrow, end }}
-	<Banner {id} start={new Date(start)} end={end ? new Date(end) : undefined} {arrow} {href}>
+{#each showing as { content, href, id, arrow }}
+	<Banner {id} {arrow} {href}>
 		{@html content}
 	</Banner>
 {/each}

--- a/packages/site-kit/src/lib/components/Banners.svelte
+++ b/packages/site-kit/src/lib/components/Banners.svelte
@@ -11,6 +11,8 @@
 	 * content: string;
 	 * scope?: BannerScope[];
 	 * }[]} BannerData
+	 *
+	 * @typedef {(Omit<BannerData[0], 'start' | 'end'> & { start: Date, end?: Date })[]} BannerDataInput
 	 */
 
 	/**
@@ -47,6 +49,18 @@
 		return /** @type {BannerData} */ (await req.json()).filter(
 			(banner) => !banner.scope || banner.scope?.includes(scope)
 		);
+	}
+
+	/**
+	 * @param {BannerDataInput} data
+	 * @returns {BannerData}
+	 */
+	export function defineBanner(data) {
+		return data.map((v) => ({
+			...v,
+			start: +v.start,
+			end: v.end ? +v.end : +new Date('2023-12-01')
+		}));
 	}
 </script>
 

--- a/packages/site-kit/src/lib/components/index.js
+++ b/packages/site-kit/src/lib/components/index.js
@@ -1,4 +1,4 @@
-export { default as Banners, fetchBanner } from './Banners.svelte';
+export { default as Banners, defineBanner, fetchBanner } from './Banners.svelte';
 export { default as Icon } from './Icon.svelte';
 export { default as Icons } from './Icons.svelte';
 export { default as Section } from './Section.svelte';


### PR DESCRIPTION
Refactors Banners component to do the gruntwork, Banner is now responsible only for changing the local persistence.

Added in error in case any two banners have overlapping timeframes. This will fail the build completely

Also exposes a new method: `defineBanner`