### PR TITLE
fix: add accessible text to copy code button

### DIFF
--- a/.changeset/olive-eggs-develop.md
+++ b/.changeset/olive-eggs-develop.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/site-kit": patch
+---
+
+fix: Accessible text for copy button

--- a/packages/site-kit/src/lib/docs/DocsCopyCodeButton.svelte
+++ b/packages/site-kit/src/lib/docs/DocsCopyCodeButton.svelte
@@ -52,6 +52,7 @@
 			<Icon name="copy-to-clipboard-empty" />
 		</span>
 	{/if}
+	<span class="visually-hidden">copy to clipboard</span>
 </button>
 
 <style>


### PR DESCRIPTION
The copy code button currently has no accessible name. This fixes this by adding a hidden span