### PR TITLE
fix: url tokenizer to not treat package version string as email

### DIFF
--- a/.changeset/odd-waves-glow.md
+++ b/.changeset/odd-waves-glow.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/site-kit': patch
+---
+
+fix: url tokenizer to not treat package version string as email

--- a/packages/site-kit/src/lib/markdown/utils.js
+++ b/packages/site-kit/src/lib/markdown/utils.js
@@ -208,6 +208,18 @@ const default_renderer = {
 	}
 };
 
+const tokenizer = {
+	url(src) {
+		// if `src` is a package version string, eg: adapter-auto@1.2.3
+		// do not tokenize it as email
+		if (/@\d+\.\d+\.\d+/.test(src)) {
+			return undefined;
+		}
+		// else, use the default tokenizer behavior
+		return false;
+	}
+};
+
 /**
  * @param {string} markdown
  * @param {Partial<import('marked').Renderer>} renderer
@@ -217,7 +229,8 @@ export async function transform(markdown, renderer = {}) {
 		renderer: {
 			...default_renderer,
 			...renderer
-		}
+		},
+		tokenizer
 	});
 
 	return (await marked.parse(markdown)) ?? '';

--- a/packages/site-kit/src/lib/markdown/utils.js
+++ b/packages/site-kit/src/lib/markdown/utils.js
@@ -208,6 +208,7 @@ const default_renderer = {
 	}
 };
 
+/** @type {import('marked').TokenizerObject} */
 const tokenizer = {
 	url(src) {
 		// if `src` is a package version string, eg: adapter-auto@1.2.3


### PR DESCRIPTION
fixes https://github.com/sveltejs/svelte/issues/11100