### PR TITLE
Fix scrollbar to draggable

### DIFF
--- a/packages/site-kit/src/lib/components/Shell.svelte
+++ b/packages/site-kit/src/lib/components/Shell.svelte
@@ -94,7 +94,6 @@ The main shell of the application. It provides a slot for the top navigation, th
 		padding-bottom: var(--sk-banner-bottom-height);
 		overflow: hidden;
 		overflow-y: auto;
-		height: 100%;
 	}
 
 	@media (max-width: 800px) {


### PR DESCRIPTION
Fixes #276 and sveltejs/kit#12423.

The commit that added `height:100%;` https://github.com/sveltejs/site-kit/commit/7b607787bb3ece4b72ebab7529f80184aafe2a58#diff-646c4a4d8d44a37b1082a9dcec99774de9b88f93945e7843d4b0e9e606a24de0R88 fixed https://github.com/sveltejs/kit/issues/10292 and in my testing the browser still correctly scrolls back to correct position when pressing the back button after my commit.

Related:
There was a past scrollbar issue sveltejs/svelte#5325 that was fixed by removing `height:100%;` from the main tag https://github.com/sveltejs/svelte/pull/5342/commits/a1af1e529898fe5e5a7ebd8cd25cc17ee3b84178 (before it was moved to a separate repo/component in https://github.com/sveltejs/svelte/commit/bad1780d487406d543bc30ef586e9c069e33d133#diff-81aa9fa32da25a5a82688cc86ff1689b70824846d2eeaac912d6cdb6059fb054L62 ).